### PR TITLE
Have a single goroutine convert incoming data

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -61,7 +61,6 @@ func NewStream(dbConfig *DatabaseConfig, slot string, startPos LogPos) *Stream {
 		dataEvents: make(chan interface{}),
 		msgChan:    make(chan *decoderbufs.RowMessage),
 	}
-	go stream.convertData()
 	return stream
 }
 


### PR DESCRIPTION
Two `convertData()` goroutines process `pq_recvlogical` output concurrently ([here](https://github.com/liquidm/llsr/compare/fix_race_condition_on_converting_incoming_data?expand=1#diff-e2d91404d5609adc9273e4603f6ce67dL64) and [here](https://github.com/liquidm/llsr/compare/fix_race_condition_on_converting_incoming_data?expand=1#diff-e2d91404d5609adc9273e4603f6ce67dR94)).

As a result, the order of entries in `msgChan` might be different than that in `dataEvents`.